### PR TITLE
Make parse_buffer and checksum calculator public

### DIFF
--- a/ant/src/drivers/mod.rs
+++ b/ant/src/drivers/mod.rs
@@ -138,6 +138,7 @@ const HEADER_SIZE: usize = 3;
 
 type Buffer = ArrayVec<u8, ANT_MESSAGE_SIZE>;
 
+/// Parse raw bytes into an `AntMessage`
 pub fn parse_buffer<E>(buf: &[u8]) -> Result<Option<AntMessage>, DriverError<E>> {
     // Not enough bytes
     if buf.len() < HEADER_SIZE {

--- a/ant/src/drivers/mod.rs
+++ b/ant/src/drivers/mod.rs
@@ -138,7 +138,7 @@ const HEADER_SIZE: usize = 3;
 
 type Buffer = ArrayVec<u8, ANT_MESSAGE_SIZE>;
 
-fn parse_buffer<E>(buf: &[u8]) -> Result<Option<AntMessage>, DriverError<E>> {
+pub fn parse_buffer<E>(buf: &[u8]) -> Result<Option<AntMessage>, DriverError<E>> {
     // Not enough bytes
     if buf.len() < HEADER_SIZE {
         return Ok(None);

--- a/ant/src/drivers/mod.rs
+++ b/ant/src/drivers/mod.rs
@@ -83,7 +83,7 @@ impl<E> From<arrayvec::CapacityError> for DriverError<E> {
     }
 }
 
-fn calculate_checksum(buf: &[u8]) -> u8 {
+pub fn calculate_checksum(buf: &[u8]) -> u8 {
     buf.iter().fold(0, |acc, x| acc ^ x)
 }
 


### PR DESCRIPTION
Addresses #6 
Allows one to create an `AntMessage` from any source and not be forced to use a provided driver.
Possibly also makes it easier to create new drivers.